### PR TITLE
`Bun` support

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,11 @@
                 "default": true,
                 "description": "Enable pnpm package manager."
             },
+            "package-manager-intellisense.bun.enable": {
+                "type": "boolean",
+                "default": true,
+                "description": "Enable bun package manager."
+            },
             "package-manager-intellisense.composer.enable": {
                 "type": "boolean",
                 "default": true,

--- a/src/package_manager/package_managers/javascript.ts
+++ b/src/package_manager/package_managers/javascript.ts
@@ -4,8 +4,8 @@ import { PackageManager } from '../../interfaces/package_manager';
 import { LanguagePackageManager } from '../language_package_manager';
 import { pathJoin } from '../../util/globals';
 
-type JavascriptPackageManager = 'npm' | 'yarn' | 'pnpm';
-type JavascriptDependenciesLockFile = 'package-lock.json' | 'yarn.lock' | 'pnpm-lock.yaml';
+type JavascriptPackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
+type JavascriptDependenciesLockFile = 'package-lock.json' | 'yarn.lock' | 'pnpm-lock.yaml' | 'bun.lock';
 
 export class Javascript extends LanguagePackageManager implements PackageManager {
     packageManager: JavascriptPackageManager = 'npm';
@@ -13,15 +13,18 @@ export class Javascript extends LanguagePackageManager implements PackageManager
         'npm': 'package-lock.json',
         'yarn': 'yarn.lock',
         'pnpm': 'pnpm-lock.yaml',
+        'bun': 'bun.lock',
     };
     startsWith: {[key in JavascriptPackageManager]: string} = {
         'npm': 'packageName',
         'yarn': 'packageName@',
         'pnpm': '/packageName/',
+        'bun': 'packageName',
     };
 
     async getInstalled(packageName: string): Promise<any> {
         this.packageManager = await this.getPackageManager();
+
         const installedPackages = new Parser(this.packageManager).parse(await this.lockFileContent());
 
         if (!vscode.workspace.getConfiguration().get(`package-manager-intellisense.${this.packageManager}.enable`)) {

--- a/src/parser/BunLock.ts
+++ b/src/parser/BunLock.ts
@@ -1,0 +1,26 @@
+import { LockParser } from "../interfaces/lock_parser";
+
+export class BunLock implements LockParser {
+    private content: {[key: string]: any};
+
+    constructor(content: string) {
+        content = this.removeTrailingCommas(content);
+        this.content = JSON.parse(content);
+
+        return this;
+    }
+
+    dependencies(): {[key: string]: any} {
+        Object.keys(this.content.packages).map(pkg => {
+            const version = this.content.packages[pkg][0].split('@').at(-1);
+            this.content.packages[pkg]['version'] = version;
+        });
+        return this.content.packages;
+    }
+
+    removeTrailingCommas(content: string): string {
+        const regex = /\,(?!\s*?[\{\[\"\'\w])/g;
+
+        return content.replace(regex, '');
+    }
+}

--- a/src/parser/BunLock.ts
+++ b/src/parser/BunLock.ts
@@ -6,15 +6,12 @@ export class BunLock implements LockParser {
     constructor(content: string) {
         content = this.removeTrailingCommas(content);
         this.content = JSON.parse(content);
+        this.appendVersions();
 
         return this;
     }
 
     dependencies(): {[key: string]: any} {
-        Object.keys(this.content.packages).map(pkg => {
-            const version = this.content.packages[pkg][0].split('@').at(-1);
-            this.content.packages[pkg]['version'] = version;
-        });
         return this.content.packages;
     }
 
@@ -22,5 +19,12 @@ export class BunLock implements LockParser {
         const regex = /\,(?!\s*?[\{\[\"\'\w])/g;
 
         return content.replace(regex, '');
+    }
+
+    appendVersions(): void {
+        Object.keys(this.content.packages).map(pkg => {
+            const version = this.content.packages[pkg][0].split('@').at(-1);
+            this.content.packages[pkg]['version'] = version;
+        });
     }
 }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -3,12 +3,14 @@ import { ComposerLock } from './composerLock';
 import { PnpmLock } from './pnpmLock';
 import { GemfileLock } from './gemfileLock';
 import { NpmLock } from './npmLock';
+import { BunLock } from './BunLock';
 
 export class Parser {
     private readonly parsers = {
         "npm": NpmLock,
         "yarn": YarnLock,
         "pnpm": PnpmLock,
+        'bun': BunLock,
         "composer": ComposerLock,
         "rubygems": GemfileLock,
     };


### PR DESCRIPTION
These dependencies were installed using `bun` with generated `bun.lock`.

![image](https://github.com/user-attachments/assets/223b5032-0bb4-4036-a6e9-f2f8918d0f78)
