### PR TITLE
[pnpm] support all pnpm lockfile versions

### DIFF
--- a/src/interfaces/lock_parser.ts
+++ b/src/interfaces/lock_parser.ts
@@ -1,3 +1,4 @@
 export interface LockParser {
     dependencies(): {[key: string]: any}
+    lockVersion(): number | null
 }

--- a/src/package_manager/package_managers/javascript.ts
+++ b/src/package_manager/package_managers/javascript.ts
@@ -21,7 +21,7 @@ export class Javascript extends LanguagePackageManager implements PackageManager
         'yarn': 'packageName@',
         /* eslint-disable @typescript-eslint/naming-convention */
         'pnpm': {
-            '5.4': '/packageName/',
+            '5.3': '/packageName/',
             '6': '/packageName@',
             '9': 'packageName@',
         },

--- a/src/package_manager/package_managers/javascript.ts
+++ b/src/package_manager/package_managers/javascript.ts
@@ -62,19 +62,26 @@ export class Javascript extends LanguagePackageManager implements PackageManager
 
     lockPackageStartsWith(packageName: string): string {
         const pattern =  this.startsWith[this.packageManager];
+
         if (typeof pattern === 'object' && this.lockVersion) {
             const lockVersion = Number(this.lockVersion);
+
             if (pattern[lockVersion]) {
                 return pattern[lockVersion].replace('packageName', packageName);
-            } else {
-                let lastVersion = Object.keys(pattern).sort().at(0);
+            }
+
+            let lastVersion = Object.keys(pattern).sort().at(0);
+
+            if (lastVersion !== undefined) {
                 for (const version of Object.keys(pattern).sort()) {
-                    if (Number(version) > lockVersion) {
+                    if (Number(version) > lockVersion ) {
                         return pattern[lastVersion].replace('packageName', packageName);
                     }
+
                     lastVersion = version;
                 }
-                return pattern[Object.keys(pattern).sort().at(-1)].replace('packageName', packageName);
+
+                return pattern[lastVersion].replace('packageName', packageName);
             }
         }
 

--- a/src/package_manager/package_managers/javascript.ts
+++ b/src/package_manager/package_managers/javascript.ts
@@ -8,7 +8,7 @@ type JavascriptPackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
 type JavascriptDependenciesLockFile = 'package-lock.json' | 'yarn.lock' | 'pnpm-lock.yaml' | 'bun.lock';
 
 export class Javascript extends LanguagePackageManager implements PackageManager {
-    packageManager: JavascriptPackageManager = 'npm';=
+    packageManager: JavascriptPackageManager = 'npm';
     packageManagerVersion: number | null = null;
     locks: {[key in JavascriptPackageManager]: JavascriptDependenciesLockFile} = {
         'npm': 'package-lock.json',
@@ -19,12 +19,14 @@ export class Javascript extends LanguagePackageManager implements PackageManager
     startsWith: {[key: string]: string | {[version: string | number]: string}} = {
         'npm': 'packageName',
         'yarn': 'packageName@',
+        /* eslint-disable @typescript-eslint/naming-convention */
         'pnpm': {
             '5.4': '/packageName/',
             '6': '/packageName@',
             '7': '/packageName@',
             '9': 'packageName@',
         },
+        /* eslint-enable */
         'bun': 'packageName',
     };
 

--- a/src/package_manager/package_managers/javascript.ts
+++ b/src/package_manager/package_managers/javascript.ts
@@ -19,13 +19,13 @@ export class Javascript extends LanguagePackageManager implements PackageManager
     startsWith: {[key: string]: string | {[version: string | number]: string}} = {
         'npm': 'packageName',
         'yarn': 'packageName@',
-        /* eslint-disable @typescript-eslint/naming-convention */
         'pnpm': {
+            /* eslint-disable @typescript-eslint/naming-convention */
             '5.3': '/packageName/',
             '6': '/packageName@',
             '9': 'packageName@',
+            /* eslint-enable */
         },
-        /* eslint-enable */
         'bun': 'packageName',
     };
 

--- a/src/package_manager/package_managers/javascript.ts
+++ b/src/package_manager/package_managers/javascript.ts
@@ -23,7 +23,6 @@ export class Javascript extends LanguagePackageManager implements PackageManager
         'pnpm': {
             '5.4': '/packageName/',
             '6': '/packageName@',
-            '7': '/packageName@',
             '9': 'packageName@',
         },
         /* eslint-enable */

--- a/src/package_manager/package_managers/javascript.ts
+++ b/src/package_manager/package_managers/javascript.ts
@@ -67,18 +67,14 @@ export class Javascript extends LanguagePackageManager implements PackageManager
             if (pattern[lockVersion]) {
                 return pattern[lockVersion].replace('packageName', packageName);
             } else {
-                if (lockVersion < Number(Object.keys(pattern).sort().at(0))) {
-                    return pattern[Object.keys(pattern).sort().at(0)].replace('packageName', packageName);
-                } else {
-                    let lastVersion = Object.keys(pattern).sort()[0];
-                    for (const version of Object.keys(pattern).sort()) {
-                        if (Number(version) > lockVersion) {
-                            return pattern[lastVersion].replace('packageName', packageName);
-                        }
-                        lastVersion = version;
+                let lastVersion = Object.keys(pattern).sort().at(0);
+                for (const version of Object.keys(pattern).sort()) {
+                    if (Number(version) > lockVersion) {
+                        return pattern[lastVersion].replace('packageName', packageName);
                     }
-                    return pattern[Object.keys(pattern).sort().at(-1)].replace('packageName', packageName);
+                    lastVersion = version;
                 }
+                return pattern[Object.keys(pattern).sort().at(-1)].replace('packageName', packageName);
             }
         }
 

--- a/src/package_manager/package_managers/php.ts
+++ b/src/package_manager/package_managers/php.ts
@@ -6,7 +6,7 @@ import { LanguagePackageManager } from '../language_package_manager';
 
 export class Php extends LanguagePackageManager implements PackageManager {
     async getInstalled(packageName: string): Promise<any> {
-        const installedPackages = new Parser("composer").parse(await this.lockFileContent());
+        const installedPackages = new Parser("composer").parse(await this.lockFileContent())['dependencies'];
 
         return installedPackages.find((pkg: types.ComposerInstalledPackage) => pkg.name === packageName);
     }

--- a/src/package_manager/package_managers/ruby.ts
+++ b/src/package_manager/package_managers/ruby.ts
@@ -5,7 +5,7 @@ import { LanguagePackageManager } from '../language_package_manager';
 
 export class Ruby extends LanguagePackageManager implements PackageManager {
     async getInstalled(packageName: string): Promise<{[key: string]: string}| undefined> {
-        const installedPackages = new Parser("rubygems").parse(await this.lockFileContent());
+        const installedPackages = new Parser("rubygems").parse(await this.lockFileContent())['dependencies'];
 
         const packageFound = Object.keys(installedPackages.GEM.specs).find((pkg: string) => pkg.startsWith(packageName));
 

--- a/src/parser/BunLock.ts
+++ b/src/parser/BunLock.ts
@@ -15,6 +15,10 @@ export class BunLock implements LockParser {
         return this.content.packages;
     }
 
+    lockVersion(): null {
+        return null;
+    }
+
     removeTrailingCommas(content: string): string {
         const regex = /\,(?!\s*?[\{\[\"\'\w])/g;
 

--- a/src/parser/composerLock.ts
+++ b/src/parser/composerLock.ts
@@ -12,4 +12,8 @@ export class ComposerLock implements LockParser {
     dependencies(): {[key: string]: any} {
         return this.content.packages;
     }
+
+    lockVersion(): null {
+        return null;
+    }
 }

--- a/src/parser/gemfileLock.ts
+++ b/src/parser/gemfileLock.ts
@@ -13,4 +13,8 @@ export class GemfileLock implements LockParser {
     dependencies(): {[key: string]: any} {
         return this.content;
     }
+
+    lockVersion(): null {
+        return null;
+    }
 }

--- a/src/parser/npmLock.ts
+++ b/src/parser/npmLock.ts
@@ -20,4 +20,8 @@ export class NpmLock implements LockParser {
 
         return new NpmLockV2(this.content).dependencies();
     }
+
+    lockVersion(): number {
+        return this.lockfileVersion;
+    }
 }

--- a/src/parser/npmLockV2.ts
+++ b/src/parser/npmLockV2.ts
@@ -8,4 +8,8 @@ export class NpmLockV2 implements LockParser {
     dependencies(): {[key: string]: any} {
         return this.content.dependencies;
     }
+
+    lockVersion(): number {
+        return 2;
+    }
 }

--- a/src/parser/npmLockV3.ts
+++ b/src/parser/npmLockV3.ts
@@ -14,4 +14,8 @@ export class NpmLockV3 implements LockParser {
 
         return dependencies;
     }
+
+    lockVersion(): number {
+        return 3;
+    }
 }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -19,8 +19,13 @@ export class Parser {
         return this;
     }
 
-    parse(content: string): {[key: string]: any} {
+    parse(content: string): {'lockVersion': number | null, 'dependencies': any} {
         // @ts-ignore
-        return new this.parsers[this.packageManager](content).dependencies();
+        const lockParser = new this.parsers[this.packageManager](content);
+
+        return {
+            'lockVersion': lockParser.lockVersion(),
+            'dependencies': lockParser.dependencies(),
+        };
     }
 }

--- a/src/parser/pnpmLock.ts
+++ b/src/parser/pnpmLock.ts
@@ -3,10 +3,12 @@ import { LockParser } from '../interfaces/lock_parser';
 
 export class PnpmLock implements LockParser {
     private content: {[key: string]: any};
+    private lockfileVersion: number;
 
     constructor(content: string) {
         // @ts-ignore
         this.content = jsYaml.load(content);
+        this.lockfileVersion = this.content.lockfileVersion;
         this.appendVersions();
 
         return this;
@@ -14,6 +16,10 @@ export class PnpmLock implements LockParser {
 
     dependencies(): {[key: string]: any} {
         return this.content.packages;
+    }
+
+    lockVersion(): number {
+        return this.lockfileVersion;
     }
 
     appendVersions(): void {

--- a/src/parser/yarnLock.ts
+++ b/src/parser/yarnLock.ts
@@ -13,4 +13,8 @@ export class YarnLock implements LockParser {
     dependencies(): {[key: string]: any} {
         return this.content.object;
     }
+
+    lockVersion(): null {
+        return null;
+    }
 }


### PR DESCRIPTION
Support `pnpm` lockfile versions breakpoints:

- [x] v5.3
- [x] v6
- [x] v9

#### Notes
- if lockfile version is lower than the lowest supported version, it will fall to the lowest supported version.
- if lockflle version is between supported versions, it will fall to the closest lower supported version.
- if lockfile version is larger that the largest supported version, it will fall to the largest supported version.