### PR TITLE
Fix package detection conflict

### DIFF
--- a/src/package_manager/language_package_manager.ts
+++ b/src/package_manager/language_package_manager.ts
@@ -68,7 +68,7 @@ export abstract class LanguagePackageManager {
             const lineText: string = document.lineAt(lineNumber).text;
             const packagePattern: string = this.packagePattern.replace('placeholder', packageName);
 
-            if (lineText.match(new RegExp(packagePattern))) {
+            if (lineText.match(new RegExp(packagePattern)) && lineText.match(/:\s*".?\d+(\.\d+){0,2}"/)) {
                 lines.push({content: lineText, package: packageName, lineNumber});
             }
         }


### PR DESCRIPTION
This PR fixes package detection conflict.

### Before
The `storybook` script is detected as dependency.
```json
"scripts": {
    "storybook": "storybook dev -p 6006"
  },
 "devDependencies": {
    "storybook": "^10.2.1"
  }
```

### After
Only the `storybook` in devDependencies is detected as dependency.